### PR TITLE
Cache proxy implemented for MyBatisInvoiceHasServiceDAO.

### DIFF
--- a/src/main/java/controllers/MainController.java
+++ b/src/main/java/controllers/MainController.java
@@ -12,10 +12,6 @@ public class MainController {
     //Factories
     private DAOFactory currentDataSourceFactory;
 
-    //Controllers
-    private PatientController patientController;
-    private AdmissionRecordController admissionRecordController;
-
     //Home views
     private final DataSourceSelection menuView = new DataSourceSelection();
     public MainController() {}

--- a/src/main/java/dao/factories/MyBatisDAOFactory.java
+++ b/src/main/java/dao/factories/MyBatisDAOFactory.java
@@ -2,6 +2,7 @@ package dao.factories;
 
 import dao.interfaces.*;
 import dao.mybatis.*;
+import dao.mybatis.proxy.MyBatisInvoiceHasServiceDAOProxy;
 import org.apache.ibatis.session.SqlSession;
 import org.apache.ibatis.session.SqlSessionFactory;
 
@@ -67,7 +68,7 @@ public class MyBatisDAOFactory extends DAOFactory{
      */
     @Override
     public InvoiceHasServiceDAO getInvoiceHasServiceDAO() {
-        return new MyBatisInvoiceHasServiceDAO();
+        return new MyBatisInvoiceHasServiceDAOProxy();
     }
 
     /**

--- a/src/main/java/dao/factories/MyBatisDAOFactory.java
+++ b/src/main/java/dao/factories/MyBatisDAOFactory.java
@@ -1,8 +1,9 @@
 package dao.factories;
 
 import dao.interfaces.*;
-import dao.mybatis.*;
+import dao.mybatis.proxy.*;
 import dao.mybatis.proxy.MyBatisInvoiceHasServiceDAOProxy;
+import dao.mybatis.proxy.MyBatisPrescriptionHasMedicineDAOProxy;
 import org.apache.ibatis.session.SqlSession;
 import org.apache.ibatis.session.SqlSessionFactory;
 
@@ -20,7 +21,7 @@ public class MyBatisDAOFactory extends DAOFactory{
      */
     @Override
     public ConsultationDAO getConsultationDAO() {
-        return new MyBatisConsultationDAO();
+        return new MyBatisConsultationDAOProxy();
     }
 
     /**
@@ -28,7 +29,7 @@ public class MyBatisDAOFactory extends DAOFactory{
      */
     @Override
     public PatientDAO getPatientDAO() {
-        return new MyBatisPatientDAO();
+        return new MyBatisPatientDAOProxy();
     }
 
     /**
@@ -36,7 +37,7 @@ public class MyBatisDAOFactory extends DAOFactory{
      */
     @Override
     public DoctorDAO getDoctorDAO() {
-        return new MyBatisDoctorDAO();
+        return new MyBatisDoctorDAOProxy();
     }
 
     /**
@@ -44,7 +45,7 @@ public class MyBatisDAOFactory extends DAOFactory{
      */
     @Override
     public AdmissionRecordDAO getAdmissionRecordDAO() {
-        return new MyBatisAdmissionRecordDAO();
+        return new MyBatisAdmissionRecordDAOProxy();
     }
 
     /**
@@ -52,7 +53,7 @@ public class MyBatisDAOFactory extends DAOFactory{
      */
     @Override
     public EmergencyContactDAO getEmergencyContactDAO() {
-        return new MyBatisEmergencyContactDAO();
+        return new MyBatisEmergencyContactDAOProxy();
     }
 
     /**
@@ -60,7 +61,7 @@ public class MyBatisDAOFactory extends DAOFactory{
      */
     @Override
     public InvoiceDAO getInvoiceDAO() {
-        return new MyBatisInvoiceDAO();
+        return new MyBatisInvoiceDAOProxy();
     }
 
     /**
@@ -76,7 +77,7 @@ public class MyBatisDAOFactory extends DAOFactory{
      */
     @Override
     public MedicineDAO getMedicineDAO() {
-        return new MyBatisMedicineDAO();
+        return new MyBatisMedicineDAOProxy();
     }
 
     /**
@@ -84,7 +85,7 @@ public class MyBatisDAOFactory extends DAOFactory{
      */
     @Override
     public PrescriptionDAO getPrescriptionDAO() {
-        return new MyBatisPrescriptionDAO();
+        return new MyBatisPrescriptionDAOProxy();
     }
 
     /**
@@ -92,7 +93,7 @@ public class MyBatisDAOFactory extends DAOFactory{
      */
     @Override
     public PrescriptionHasMedicineDAO getPrescriptionHasMedicineDAO() {
-        return new MyBatisPrescriptionHasMedicineDAO();
+        return new MyBatisPrescriptionHasMedicineDAOProxy();
     }
 
     /**
@@ -100,7 +101,7 @@ public class MyBatisDAOFactory extends DAOFactory{
      */
     @Override
     public ServiceDAO getServiceDAO() {
-        return new MyBatisServiceDAO();
+        return new MyBatisServiceDAOProxy();
     }
 
     /**
@@ -108,6 +109,6 @@ public class MyBatisDAOFactory extends DAOFactory{
      */
     @Override
     public TreatmentRecordDAO getTreatmentRecordDAO() {
-        return new MyBatisTreatmentRecordDAO();
+        return new MyBatisTreatmentRecordDAOProxy();
     }
 }

--- a/src/main/java/dao/interfaces/InvoiceHasServiceDAO.java
+++ b/src/main/java/dao/interfaces/InvoiceHasServiceDAO.java
@@ -1,6 +1,7 @@
 package dao.interfaces;
 
 import models.InvoiceHasService;
+import org.apache.ibatis.annotations.Param;
 
 import java.util.List;
 import java.util.Optional;
@@ -8,8 +9,8 @@ import java.util.Optional;
 public interface InvoiceHasServiceDAO extends JointTableCrud<InvoiceHasService> {
     int update(InvoiceHasService obj);
     int insert(InvoiceHasService obj);
-    int delete(int invoiceId, int serviceId);
-    Optional<InvoiceHasService> select(int invoiceId, int serviceId);
+    int delete(@Param("invoiceId") int invoiceId, @Param("serviceId") int serviceId);
+    Optional<InvoiceHasService> select(@Param("invoiceId") int invoiceId, @Param("serviceId") int serviceId);
     List<InvoiceHasService> selectByInvoice(int invoiceId);
     List<InvoiceHasService> selectByService(int serviceId);
 

--- a/src/main/java/dao/interfaces/PrescriptionHasMedicineDAO.java
+++ b/src/main/java/dao/interfaces/PrescriptionHasMedicineDAO.java
@@ -1,6 +1,7 @@
 package dao.interfaces;
 
 import models.PrescriptionHasMedicine;
+import org.apache.ibatis.annotations.Param;
 
 import java.util.List;
 import java.util.Optional;
@@ -8,8 +9,8 @@ import java.util.Optional;
 public interface PrescriptionHasMedicineDAO extends JointTableCrud<PrescriptionHasMedicine> {
     int insert(PrescriptionHasMedicine obj);
     int update(PrescriptionHasMedicine obj);
-    int delete(int prescriptionId, int medicineId);
-    Optional<PrescriptionHasMedicine> select(int prescriptionId, int medicineId);
+    int delete(@Param("prescriptionId") int prescriptionId, @Param("medicineId") int medicineId);
+    Optional<PrescriptionHasMedicine> select(@Param("prescriptionId") int prescriptionId, @Param("medicineId") int medicineId);
     List<PrescriptionHasMedicine> selectByPrescription(int prescriptionId);
     List<PrescriptionHasMedicine> selectByMedicine(int medicineId);
 

--- a/src/main/java/dao/mybatis/proxy/CacheProxy.java
+++ b/src/main/java/dao/mybatis/proxy/CacheProxy.java
@@ -1,0 +1,18 @@
+package dao.mybatis.proxy;
+
+import static java.time.Instant.now;
+
+public abstract class CacheProxy {
+    protected long lastUpdate = now().getNano() / 1000_000_000;
+    protected boolean invalidateCache = false;
+
+    public boolean needsUpdate(){
+        boolean timedOut = now().getNano() / 1000_000_000 - lastUpdate > 30;
+
+        return timedOut || invalidateCache;
+    }
+
+    public void setLastUpdate(){
+        lastUpdate = now().getNano() / 1000_000_000;
+    }
+}

--- a/src/main/java/dao/mybatis/proxy/MyBatisAdmissionRecordDAOProxy.java
+++ b/src/main/java/dao/mybatis/proxy/MyBatisAdmissionRecordDAOProxy.java
@@ -1,0 +1,113 @@
+package dao.mybatis.proxy;
+
+import dao.interfaces.AdmissionRecordDAO;
+import dao.mybatis.MyBatisAdmissionRecordDAO;
+import models.AdmissionRecord;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Optional;
+
+import static java.time.Instant.now;
+
+public class MyBatisAdmissionRecordDAOProxy extends CacheProxy implements AdmissionRecordDAO {
+    private MyBatisAdmissionRecordDAO currentDao = new MyBatisAdmissionRecordDAO();
+    private Logger logger = LogManager.getLogger(MyBatisAdmissionRecordDAOProxy.class);
+
+    private HashMap<Integer, Optional<AdmissionRecord>> lastSelected = new HashMap<>();
+    private List<AdmissionRecord> lastSelectAll = null;
+
+    /**
+     * @param obj
+     */
+    @Override
+    public int insert(AdmissionRecord obj) {
+        logger.traceEntry();
+        logger.debug("Attempting to insert admissionRecord.");
+
+        int modifiedRows = currentDao.insert(obj);
+        invalidateCache = modifiedRows > 0;
+
+        return logger.traceExit(modifiedRows);
+    }
+
+    /**
+     * @param id
+     * @param obj
+     */
+    @Override
+    public int update(int id, AdmissionRecord obj) {
+        logger.traceEntry();
+        logger.debug("Attempting to update admissionRecord.");
+
+        int modifiedRows = currentDao.update(id, obj);
+        invalidateCache = modifiedRows > 0;
+
+        return logger.traceExit(modifiedRows);
+    }
+
+    /**
+     * @param id
+     */
+    @Override
+    public int delete(int id) {
+        logger.traceEntry();
+        logger.debug("Attempting to delete admissionRecord.");
+
+        int modifiedRows = currentDao.delete(id);
+        invalidateCache = modifiedRows > 0;
+
+        return logger.traceExit(modifiedRows);
+    }
+
+    /**
+     * @param id
+     * @return
+     */
+    @Override
+    public Optional<AdmissionRecord> select(int id) {
+        logger.traceEntry();
+        logger.debug("Checking AdmissionRecord selectById cache.");
+
+        if (lastSelected.get(id) == null || needsUpdate()){
+            logger.debug("Result not cached, attempting to query database.");
+            lastSelected.put(id, currentDao.select(id));
+            setLastUpdate();
+            return lastSelected.get(id);
+        }
+
+        logger.debug("Cache exists. Returning cached result.");
+        return logger.traceExit(lastSelected.get(id));
+    }
+
+    /**
+     * @return
+     */
+    @Override
+    public List<AdmissionRecord> selectAll() {
+        logger.traceEntry();
+        logger.debug("Checking AdmissionRecord selectById cache.");
+
+        if (lastSelectAll == null || needsUpdate()){
+            logger.debug("Result not cached, attempting to query database.");
+            lastSelectAll = currentDao.selectAll();
+            setLastUpdate();
+            return lastSelectAll;
+        }
+
+        logger.debug("Cache exists. Returning cached result.");
+        return logger.traceExit(lastSelectAll);
+    }
+
+    public boolean needsUpdate(){
+        boolean timedOut = now().getNano() / 1000_000_000 - lastUpdate > 30;
+
+        return timedOut || invalidateCache;
+    }
+
+    public void setLastUpdate(){
+        lastUpdate = now().getNano() / 1000_000_000;
+    }
+}

--- a/src/main/java/dao/mybatis/proxy/MyBatisConsultationDAOProxy.java
+++ b/src/main/java/dao/mybatis/proxy/MyBatisConsultationDAOProxy.java
@@ -1,0 +1,113 @@
+package dao.mybatis.proxy;
+
+import dao.interfaces.ConsultationDAO;
+import dao.mybatis.MyBatisConsultationDAO;
+import models.Consultation;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Optional;
+
+import static java.time.Instant.now;
+
+public class MyBatisConsultationDAOProxy extends CacheProxy implements ConsultationDAO {
+    private MyBatisConsultationDAO currentDao = new MyBatisConsultationDAO();
+    private Logger logger = LogManager.getLogger(MyBatisConsultationDAOProxy.class);
+
+    private HashMap<Integer, Optional<Consultation>> lastSelected = new HashMap<>();
+    private List<Consultation> lastSelectAll = null;
+
+    /**
+     * @param obj
+     */
+    @Override
+    public int insert(Consultation obj) {
+        logger.traceEntry();
+        logger.debug("Attempting to insert consultation.");
+
+        int modifiedRows = currentDao.insert(obj);
+        invalidateCache = modifiedRows > 0;
+
+        return logger.traceExit(modifiedRows);
+    }
+
+    /**
+     * @param id
+     * @param obj
+     */
+    @Override
+    public int update(int id, Consultation obj) {
+        logger.traceEntry();
+        logger.debug("Attempting to update consultation.");
+
+        int modifiedRows = currentDao.update(id, obj);
+        invalidateCache = modifiedRows > 0;
+
+        return logger.traceExit(modifiedRows);
+    }
+
+    /**
+     * @param id
+     */
+    @Override
+    public int delete(int id) {
+        logger.traceEntry();
+        logger.debug("Attempting to delete consultation.");
+
+        int modifiedRows = currentDao.delete(id);
+        invalidateCache = modifiedRows > 0;
+
+        return logger.traceExit(modifiedRows);
+    }
+
+    /**
+     * @param id
+     * @return
+     */
+    @Override
+    public Optional<Consultation> select(int id) {
+        logger.traceEntry();
+        logger.debug("Checking Consultation selectById cache.");
+
+        if (lastSelected.get(id) == null || needsUpdate()){
+            logger.debug("Result not cached, attempting to query database.");
+            lastSelected.put(id, currentDao.select(id));
+            setLastUpdate();
+            return lastSelected.get(id);
+        }
+
+        logger.debug("Cache exists. Returning cached result.");
+        return logger.traceExit(lastSelected.get(id));
+    }
+
+    /**
+     * @return
+     */
+    @Override
+    public List<Consultation> selectAll() {
+        logger.traceEntry();
+        logger.debug("Checking Consultation selectById cache.");
+
+        if (lastSelectAll == null || needsUpdate()){
+            logger.debug("Result not cached, attempting to query database.");
+            lastSelectAll = currentDao.selectAll();
+            setLastUpdate();
+            return lastSelectAll;
+        }
+
+        logger.debug("Cache exists. Returning cached result.");
+        return logger.traceExit(lastSelectAll);
+    }
+
+    public boolean needsUpdate(){
+        boolean timedOut = now().getNano() / 1000_000_000 - lastUpdate > 30;
+
+        return timedOut || invalidateCache;
+    }
+
+    public void setLastUpdate(){
+        lastUpdate = now().getNano() / 1000_000_000;
+    }
+}

--- a/src/main/java/dao/mybatis/proxy/MyBatisDoctorDAOProxy.java
+++ b/src/main/java/dao/mybatis/proxy/MyBatisDoctorDAOProxy.java
@@ -1,0 +1,113 @@
+package dao.mybatis.proxy;
+
+import dao.interfaces.DoctorDAO;
+import dao.mybatis.MyBatisDoctorDAO;
+import models.Doctor;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Optional;
+
+import static java.time.Instant.now;
+
+public class MyBatisDoctorDAOProxy extends CacheProxy implements DoctorDAO {
+    private MyBatisDoctorDAO currentDao = new MyBatisDoctorDAO();
+    private Logger logger = LogManager.getLogger(MyBatisDoctorDAOProxy.class);
+
+    private HashMap<Integer, Optional<Doctor>> lastSelected = new HashMap<>();
+    private List<Doctor> lastSelectAll = null;
+
+    /**
+     * @param obj
+     */
+    @Override
+    public int insert(Doctor obj) {
+        logger.traceEntry();
+        logger.debug("Attempting to insert doctor.");
+
+        int modifiedRows = currentDao.insert(obj);
+        invalidateCache = modifiedRows > 0;
+
+        return logger.traceExit(modifiedRows);
+    }
+
+    /**
+     * @param id
+     * @param obj
+     */
+    @Override
+    public int update(int id, Doctor obj) {
+        logger.traceEntry();
+        logger.debug("Attempting to update doctor.");
+
+        int modifiedRows = currentDao.update(id, obj);
+        invalidateCache = modifiedRows > 0;
+
+        return logger.traceExit(modifiedRows);
+    }
+
+    /**
+     * @param id
+     */
+    @Override
+    public int delete(int id) {
+        logger.traceEntry();
+        logger.debug("Attempting to delete doctor.");
+
+        int modifiedRows = currentDao.delete(id);
+        invalidateCache = modifiedRows > 0;
+
+        return logger.traceExit(modifiedRows);
+    }
+
+    /**
+     * @param id
+     * @return
+     */
+    @Override
+    public Optional<Doctor> select(int id) {
+        logger.traceEntry();
+        logger.debug("Checking Doctor selectById cache.");
+
+        if (lastSelected.get(id) == null || needsUpdate()){
+            logger.debug("Result not cached, attempting to query database.");
+            lastSelected.put(id, currentDao.select(id));
+            setLastUpdate();
+            return lastSelected.get(id);
+        }
+
+        logger.debug("Cache exists. Returning cached result.");
+        return logger.traceExit(lastSelected.get(id));
+    }
+
+    /**
+     * @return
+     */
+    @Override
+    public List<Doctor> selectAll() {
+        logger.traceEntry();
+        logger.debug("Checking Doctor selectById cache.");
+
+        if (lastSelectAll == null || needsUpdate()){
+            logger.debug("Result not cached, attempting to query database.");
+            lastSelectAll = currentDao.selectAll();
+            setLastUpdate();
+            return lastSelectAll;
+        }
+
+        logger.debug("Cache exists. Returning cached result.");
+        return logger.traceExit(lastSelectAll);
+    }
+
+    public boolean needsUpdate(){
+        boolean timedOut = now().getNano() / 1000_000_000 - lastUpdate > 30;
+
+        return timedOut || invalidateCache;
+    }
+
+    public void setLastUpdate(){
+        lastUpdate = now().getNano() / 1000_000_000;
+    }
+}

--- a/src/main/java/dao/mybatis/proxy/MyBatisEmergencyContactDAOProxy.java
+++ b/src/main/java/dao/mybatis/proxy/MyBatisEmergencyContactDAOProxy.java
@@ -1,0 +1,113 @@
+package dao.mybatis.proxy;
+
+import dao.interfaces.EmergencyContactDAO;
+import dao.mybatis.MyBatisEmergencyContactDAO;
+import models.EmergencyContact;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Optional;
+
+import static java.time.Instant.now;
+
+public class MyBatisEmergencyContactDAOProxy extends CacheProxy implements EmergencyContactDAO {
+    private MyBatisEmergencyContactDAO currentDao = new MyBatisEmergencyContactDAO();
+    private Logger logger = LogManager.getLogger(MyBatisEmergencyContactDAOProxy.class);
+
+    private HashMap<Integer, Optional<EmergencyContact>> lastSelected = new HashMap<>();
+    private List<EmergencyContact> lastSelectAll = null;
+
+    /**
+     * @param obj
+     */
+    @Override
+    public int insert(EmergencyContact obj) {
+        logger.traceEntry();
+        logger.debug("Attempting to insert emergencyContact.");
+
+        int modifiedRows = currentDao.insert(obj);
+        invalidateCache = modifiedRows > 0;
+
+        return logger.traceExit(modifiedRows);
+    }
+
+    /**
+     * @param id
+     * @param obj
+     */
+    @Override
+    public int update(int id, EmergencyContact obj) {
+        logger.traceEntry();
+        logger.debug("Attempting to update emergencyContact.");
+
+        int modifiedRows = currentDao.update(id, obj);
+        invalidateCache = modifiedRows > 0;
+
+        return logger.traceExit(modifiedRows);
+    }
+
+    /**
+     * @param id
+     */
+    @Override
+    public int delete(int id) {
+        logger.traceEntry();
+        logger.debug("Attempting to delete emergencyContact.");
+
+        int modifiedRows = currentDao.delete(id);
+        invalidateCache = modifiedRows > 0;
+
+        return logger.traceExit(modifiedRows);
+    }
+
+    /**
+     * @param id
+     * @return
+     */
+    @Override
+    public Optional<EmergencyContact> select(int id) {
+        logger.traceEntry();
+        logger.debug("Checking EmergencyContact selectById cache.");
+
+        if (lastSelected.get(id) == null || needsUpdate()){
+            logger.debug("Result not cached, attempting to query database.");
+            lastSelected.put(id, currentDao.select(id));
+            setLastUpdate();
+            return lastSelected.get(id);
+        }
+
+        logger.debug("Cache exists. Returning cached result.");
+        return logger.traceExit(lastSelected.get(id));
+    }
+
+    /**
+     * @return
+     */
+    @Override
+    public List<EmergencyContact> selectAll() {
+        logger.traceEntry();
+        logger.debug("Checking EmergencyContact selectById cache.");
+
+        if (lastSelectAll == null || needsUpdate()){
+            logger.debug("Result not cached, attempting to query database.");
+            lastSelectAll = currentDao.selectAll();
+            setLastUpdate();
+            return lastSelectAll;
+        }
+
+        logger.debug("Cache exists. Returning cached result.");
+        return logger.traceExit(lastSelectAll);
+    }
+
+    public boolean needsUpdate(){
+        boolean timedOut = now().getNano() / 1000_000_000 - lastUpdate > 30;
+
+        return timedOut || invalidateCache;
+    }
+
+    public void setLastUpdate(){
+        lastUpdate = now().getNano() / 1000_000_000;
+    }
+}

--- a/src/main/java/dao/mybatis/proxy/MyBatisInvoiceDAOProxy.java
+++ b/src/main/java/dao/mybatis/proxy/MyBatisInvoiceDAOProxy.java
@@ -1,0 +1,113 @@
+package dao.mybatis.proxy;
+
+import dao.interfaces.InvoiceDAO;
+import dao.mybatis.MyBatisInvoiceDAO;
+import models.Invoice;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Optional;
+
+import static java.time.Instant.now;
+
+public class MyBatisInvoiceDAOProxy extends CacheProxy implements InvoiceDAO {
+    private MyBatisInvoiceDAO currentDao = new MyBatisInvoiceDAO();
+    private Logger logger = LogManager.getLogger(MyBatisInvoiceDAOProxy.class);
+
+    private HashMap<Integer, Optional<Invoice>> lastSelected = new HashMap<>();
+    private List<Invoice> lastSelectAll = null;
+
+    /**
+     * @param obj
+     */
+    @Override
+    public int insert(Invoice obj) {
+        logger.traceEntry();
+        logger.debug("Attempting to insert invoice.");
+
+        int modifiedRows = currentDao.insert(obj);
+        invalidateCache = modifiedRows > 0;
+
+        return logger.traceExit(modifiedRows);
+    }
+
+    /**
+     * @param id
+     * @param obj
+     */
+    @Override
+    public int update(int id, Invoice obj) {
+        logger.traceEntry();
+        logger.debug("Attempting to update invoice.");
+
+        int modifiedRows = currentDao.update(id, obj);
+        invalidateCache = modifiedRows > 0;
+
+        return logger.traceExit(modifiedRows);
+    }
+
+    /**
+     * @param id
+     */
+    @Override
+    public int delete(int id) {
+        logger.traceEntry();
+        logger.debug("Attempting to delete invoice.");
+
+        int modifiedRows = currentDao.delete(id);
+        invalidateCache = modifiedRows > 0;
+
+        return logger.traceExit(modifiedRows);
+    }
+
+    /**
+     * @param id
+     * @return
+     */
+    @Override
+    public Optional<Invoice> select(int id) {
+        logger.traceEntry();
+        logger.debug("Checking Invoice selectById cache.");
+
+        if (lastSelected.get(id) == null || needsUpdate()){
+            logger.debug("Result not cached, attempting to query database.");
+            lastSelected.put(id, currentDao.select(id));
+            setLastUpdate();
+            return lastSelected.get(id);
+        }
+
+        logger.debug("Cache exists. Returning cached result.");
+        return logger.traceExit(lastSelected.get(id));
+    }
+
+    /**
+     * @return
+     */
+    @Override
+    public List<Invoice> selectAll() {
+        logger.traceEntry();
+        logger.debug("Checking Invoice selectById cache.");
+
+        if (lastSelectAll == null || needsUpdate()){
+            logger.debug("Result not cached, attempting to query database.");
+            lastSelectAll = currentDao.selectAll();
+            setLastUpdate();
+            return lastSelectAll;
+        }
+
+        logger.debug("Cache exists. Returning cached result.");
+        return logger.traceExit(lastSelectAll);
+    }
+
+    public boolean needsUpdate(){
+        boolean timedOut = now().getNano() / 1000_000_000 - lastUpdate > 30;
+
+        return timedOut || invalidateCache;
+    }
+
+    public void setLastUpdate(){
+        lastUpdate = now().getNano() / 1000_000_000;
+    }
+}

--- a/src/main/java/dao/mybatis/proxy/MyBatisInvoiceHasServiceDAOProxy.java
+++ b/src/main/java/dao/mybatis/proxy/MyBatisInvoiceHasServiceDAOProxy.java
@@ -1,0 +1,159 @@
+package dao.mybatis.proxy;
+
+import dao.interfaces.InvoiceHasServiceDAO;
+import dao.mybatis.MyBatisInvoiceHasServiceDAO;
+import models.InvoiceHasService;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+
+import java.util.AbstractMap.SimpleEntry;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Optional;
+
+import static java.time.Instant.now;
+
+public class MyBatisInvoiceHasServiceDAOProxy implements InvoiceHasServiceDAO {
+    private MyBatisInvoiceHasServiceDAO currentDao = new MyBatisInvoiceHasServiceDAO();
+    private Logger logger = LogManager.getLogger(MyBatisInvoiceHasServiceDAOProxy.class);
+
+    private HashMap<SimpleEntry<Integer, Integer>, Optional<InvoiceHasService>> lastSelectedInvoiceHasService = new HashMap<>();
+    private List<InvoiceHasService> lastSelectAll = null;
+    private HashMap<Integer, List<InvoiceHasService>> lastSelectAllByInvoice = new HashMap<>();
+    private HashMap<Integer, List<InvoiceHasService>> lastSelectAllByService = new HashMap<>();
+    private long lastUpdate = now().getNano() / 1000_000_000;
+    private boolean invalidateCache = false;
+
+    /**
+     * @param obj
+     */
+    @Override
+    public int insert(InvoiceHasService obj) {
+        logger.traceEntry();
+        logger.debug("Attempting to insert object.");
+        return logger.traceExit(currentDao.insert(obj));
+    }
+
+    /**
+     * @param obj
+     */
+    @Override
+    public int update(InvoiceHasService obj) {
+        logger.traceEntry();
+        logger.debug("Attempting to update object.");
+
+        int modifiedRows = currentDao.update(obj);
+        invalidateCache = modifiedRows > 0;
+
+        return logger.traceExit(modifiedRows);
+    }
+
+    @Override
+    public int delete(int invoiceId, int serviceId) {
+        logger.traceEntry();
+        logger.debug("Attempting to delete object.");
+
+        int deletedId = currentDao.delete(invoiceId, serviceId);
+        invalidateCache = deletedId > 0;
+
+        return logger.traceExit(deletedId);
+    }
+
+    @Override
+    public Optional<InvoiceHasService> select(int invoiceId, int serviceId) {
+        logger.traceEntry();
+        logger.debug("Checking InvoiceHasService selectById cache.");
+
+        SimpleEntry<Integer, Integer> ids = new SimpleEntry<>(invoiceId, serviceId);
+
+        if (lastSelectedInvoiceHasService.get(ids) == null || needsUpdate()){
+            logger.debug("Result not cached, attempting to query database.");
+            lastSelectedInvoiceHasService.put(ids, currentDao.select(invoiceId, serviceId));
+            setLastUpdate();
+            return lastSelectedInvoiceHasService.get(ids);
+        }
+
+        logger.debug("Cache exists. Returning cached result.");
+        return logger.traceExit(lastSelectedInvoiceHasService.get(ids));
+    }
+
+    /**
+     * @return
+     */
+    @Override
+    public List<InvoiceHasService> selectAll() {
+        logger.traceEntry();
+        logger.debug("Checking InvoiceHasService selectAll cache.");
+        if (lastSelectAll == null || needsUpdate()){
+            logger.debug("Result not cached, attempting to query database.");
+            lastSelectAll = currentDao.selectAll();
+            setLastUpdate();
+            return lastSelectAll;
+        }
+
+        logger.debug("Cache exists. Returning cached result.");
+        return logger.traceExit(currentDao.selectAll());
+    }
+    
+    /**
+     * @param invoiceId
+     * @return
+     */
+    @Override
+    public List<InvoiceHasService> selectByInvoice(int invoiceId) {
+        logger.traceEntry();
+        logger.debug("Checking InvoiceHasService selectByInvoice cache.");
+
+        // If there is no result cached for given invoice
+        if (lastSelectAllByInvoice.get(invoiceId) == null || needsUpdate()){
+            logger.debug("Result not cached, attempting to query database.");
+            //Cache the results for the given invoiceId
+            lastSelectAllByInvoice.put(invoiceId, currentDao.selectByInvoice(invoiceId));
+            //Reset last update time
+            setLastUpdate();
+            //Return cached results
+            return lastSelectAllByInvoice.get(invoiceId);
+        }
+        // There exist a cached result and update time hasn't been reached
+
+        logger.debug("Cache exists. Returning cached result.");
+        //Returns cached result
+        return logger.traceExit(lastSelectAllByInvoice.get(invoiceId));
+    }
+
+    /**
+     * @param serviceId
+     * @return
+     */
+    @Override
+    public List<InvoiceHasService> selectByService(int serviceId) {
+        logger.traceEntry();
+        logger.debug("Checking InvoiceHasService selectByInvoice cache.");
+
+        // If there is no result cached for given invoice
+        if (lastSelectAllByService.get(serviceId) == null || needsUpdate()){
+            logger.debug("Result not cached, attempting to query database.");
+            //Cache the results for the given invoiceId
+            lastSelectAllByService.put(serviceId, currentDao.selectByService(serviceId));
+            //Reset last update time
+            setLastUpdate();
+            //Return cached results
+            return lastSelectAllByService.get(serviceId);
+        }
+        // There exist a cached result and update time hasn't been reached
+
+        logger.debug("Cache exists. Returning cached result.");
+        //Returns cached result
+        return logger.traceExit(lastSelectAllByService.get(serviceId));
+    }
+
+    public boolean needsUpdate(){
+        boolean timedOut = now().getNano() / 1000_000_000 - lastUpdate > 30;
+
+        return timedOut || invalidateCache;
+    }
+
+    public void setLastUpdate(){
+        lastUpdate = now().getNano() / 1000_000_000;
+    }
+}

--- a/src/main/java/dao/mybatis/proxy/MyBatisMedicineDAOProxy.java
+++ b/src/main/java/dao/mybatis/proxy/MyBatisMedicineDAOProxy.java
@@ -1,0 +1,113 @@
+package dao.mybatis.proxy;
+
+import dao.interfaces.MedicineDAO;
+import dao.mybatis.MyBatisMedicineDAO;
+import models.Medicine;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Optional;
+
+import static java.time.Instant.now;
+
+public class MyBatisMedicineDAOProxy extends CacheProxy implements MedicineDAO {
+    private MyBatisMedicineDAO currentDao = new MyBatisMedicineDAO();
+    private Logger logger = LogManager.getLogger(MyBatisMedicineDAOProxy.class);
+
+    private HashMap<Integer, Optional<Medicine>> lastSelected = new HashMap<>();
+    private List<Medicine> lastSelectAll = null;
+
+    /**
+     * @param obj
+     */
+    @Override
+    public int insert(Medicine obj) {
+        logger.traceEntry();
+        logger.debug("Attempting to insert medicine.");
+
+        int modifiedRows = currentDao.insert(obj);
+        invalidateCache = modifiedRows > 0;
+
+        return logger.traceExit(modifiedRows);
+    }
+
+    /**
+     * @param id
+     * @param obj
+     */
+    @Override
+    public int update(int id, Medicine obj) {
+        logger.traceEntry();
+        logger.debug("Attempting to update medicine.");
+
+        int modifiedRows = currentDao.update(id, obj);
+        invalidateCache = modifiedRows > 0;
+
+        return logger.traceExit(modifiedRows);
+    }
+
+    /**
+     * @param id
+     */
+    @Override
+    public int delete(int id) {
+        logger.traceEntry();
+        logger.debug("Attempting to delete medicine.");
+
+        int modifiedRows = currentDao.delete(id);
+        invalidateCache = modifiedRows > 0;
+
+        return logger.traceExit(modifiedRows);
+    }
+
+    /**
+     * @param id
+     * @return
+     */
+    @Override
+    public Optional<Medicine> select(int id) {
+        logger.traceEntry();
+        logger.debug("Checking Medicine selectById cache.");
+
+        if (lastSelected.get(id) == null || needsUpdate()){
+            logger.debug("Result not cached, attempting to query database.");
+            lastSelected.put(id, currentDao.select(id));
+            setLastUpdate();
+            return lastSelected.get(id);
+        }
+
+        logger.debug("Cache exists. Returning cached result.");
+        return logger.traceExit(lastSelected.get(id));
+    }
+
+    /**
+     * @return
+     */
+    @Override
+    public List<Medicine> selectAll() {
+        logger.traceEntry();
+        logger.debug("Checking Medicine selectById cache.");
+
+        if (lastSelectAll == null || needsUpdate()){
+            logger.debug("Result not cached, attempting to query database.");
+            lastSelectAll = currentDao.selectAll();
+            setLastUpdate();
+            return lastSelectAll;
+        }
+
+        logger.debug("Cache exists. Returning cached result.");
+        return logger.traceExit(lastSelectAll);
+    }
+
+    public boolean needsUpdate(){
+        boolean timedOut = now().getNano() / 1000_000_000 - lastUpdate > 30;
+
+        return timedOut || invalidateCache;
+    }
+
+    public void setLastUpdate(){
+        lastUpdate = now().getNano() / 1000_000_000;
+    }
+}

--- a/src/main/java/dao/mybatis/proxy/MyBatisPatientDAOProxy.java
+++ b/src/main/java/dao/mybatis/proxy/MyBatisPatientDAOProxy.java
@@ -1,0 +1,114 @@
+package dao.mybatis.proxy;
+
+import dao.interfaces.PatientDAO;
+import dao.mybatis.MyBatisPatientDAO;
+import models.Patient;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+
+import java.util.AbstractMap;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Optional;
+
+import static java.time.Instant.now;
+
+public class MyBatisPatientDAOProxy extends CacheProxy implements PatientDAO {
+    private MyBatisPatientDAO currentDao = new MyBatisPatientDAO();
+    private Logger logger = LogManager.getLogger(MyBatisPatientDAOProxy.class);
+
+    private HashMap<Integer, Optional<Patient>> lastSelected = new HashMap<>();
+    private List<Patient> lastSelectAll = null;
+    
+    /**
+     * @param obj
+     */
+    @Override
+    public int insert(Patient obj) {
+        logger.traceEntry();
+        logger.debug("Attempting to insert patient.");
+
+        int modifiedRows = currentDao.insert(obj);
+        invalidateCache = modifiedRows > 0;
+
+        return logger.traceExit(modifiedRows);
+    }
+
+    /**
+     * @param id
+     * @param obj
+     */
+    @Override
+    public int update(int id, Patient obj) {
+        logger.traceEntry();
+        logger.debug("Attempting to update patient.");
+
+        int modifiedRows = currentDao.update(id, obj);
+        invalidateCache = modifiedRows > 0;
+
+        return logger.traceExit(modifiedRows);
+    }
+
+    /**
+     * @param id
+     */
+    @Override
+    public int delete(int id) {
+        logger.traceEntry();
+        logger.debug("Attempting to delete patient.");
+
+        int modifiedRows = currentDao.delete(id);
+        invalidateCache = modifiedRows > 0;
+
+        return logger.traceExit(modifiedRows);
+    }
+
+    /**
+     * @param id
+     * @return
+     */
+    @Override
+    public Optional<Patient> select(int id) {
+        logger.traceEntry();
+        logger.debug("Checking Patient selectById cache.");
+        
+        if (lastSelected.get(id) == null || needsUpdate()){
+            logger.debug("Result not cached, attempting to query database.");
+            lastSelected.put(id, currentDao.select(id));
+            setLastUpdate();
+            return lastSelected.get(id);
+        }
+
+        logger.debug("Cache exists. Returning cached result.");
+        return logger.traceExit(lastSelected.get(id));
+    }
+
+    /**
+     * @return
+     */
+    @Override
+    public List<Patient> selectAll() {
+        logger.traceEntry();
+        logger.debug("Checking Patient selectById cache.");
+
+        if (lastSelectAll == null || needsUpdate()){
+            logger.debug("Result not cached, attempting to query database.");
+            lastSelectAll = currentDao.selectAll();
+            setLastUpdate();
+            return lastSelectAll;
+        }
+
+        logger.debug("Cache exists. Returning cached result.");
+        return logger.traceExit(lastSelectAll);
+    }
+
+    public boolean needsUpdate(){
+        boolean timedOut = now().getNano() / 1000_000_000 - lastUpdate > 30;
+
+        return timedOut || invalidateCache;
+    }
+
+    public void setLastUpdate(){
+        lastUpdate = now().getNano() / 1000_000_000;
+    }
+}

--- a/src/main/java/dao/mybatis/proxy/MyBatisPrescriptionDAOProxy.java
+++ b/src/main/java/dao/mybatis/proxy/MyBatisPrescriptionDAOProxy.java
@@ -1,0 +1,113 @@
+package dao.mybatis.proxy;
+
+import dao.interfaces.PrescriptionDAO;
+import dao.mybatis.MyBatisPrescriptionDAO;
+import models.Prescription;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Optional;
+
+import static java.time.Instant.now;
+
+public class MyBatisPrescriptionDAOProxy extends CacheProxy implements PrescriptionDAO {
+    private MyBatisPrescriptionDAO currentDao = new MyBatisPrescriptionDAO();
+    private Logger logger = LogManager.getLogger(MyBatisPrescriptionDAOProxy.class);
+
+    private HashMap<Integer, Optional<Prescription>> lastSelected = new HashMap<>();
+    private List<Prescription> lastSelectAll = null;
+
+    /**
+     * @param obj
+     */
+    @Override
+    public int insert(Prescription obj) {
+        logger.traceEntry();
+        logger.debug("Attempting to insert prescription.");
+
+        int modifiedRows = currentDao.insert(obj);
+        invalidateCache = modifiedRows > 0;
+
+        return logger.traceExit(modifiedRows);
+    }
+
+    /**
+     * @param id
+     * @param obj
+     */
+    @Override
+    public int update(int id, Prescription obj) {
+        logger.traceEntry();
+        logger.debug("Attempting to update prescription.");
+
+        int modifiedRows = currentDao.update(id, obj);
+        invalidateCache = modifiedRows > 0;
+
+        return logger.traceExit(modifiedRows);
+    }
+
+    /**
+     * @param id
+     */
+    @Override
+    public int delete(int id) {
+        logger.traceEntry();
+        logger.debug("Attempting to delete prescription.");
+
+        int modifiedRows = currentDao.delete(id);
+        invalidateCache = modifiedRows > 0;
+
+        return logger.traceExit(modifiedRows);
+    }
+
+    /**
+     * @param id
+     * @return
+     */
+    @Override
+    public Optional<Prescription> select(int id) {
+        logger.traceEntry();
+        logger.debug("Checking Prescription selectById cache.");
+
+        if (lastSelected.get(id) == null || needsUpdate()){
+            logger.debug("Result not cached, attempting to query database.");
+            lastSelected.put(id, currentDao.select(id));
+            setLastUpdate();
+            return lastSelected.get(id);
+        }
+
+        logger.debug("Cache exists. Returning cached result.");
+        return logger.traceExit(lastSelected.get(id));
+    }
+
+    /**
+     * @return
+     */
+    @Override
+    public List<Prescription> selectAll() {
+        logger.traceEntry();
+        logger.debug("Checking Prescription selectById cache.");
+
+        if (lastSelectAll == null || needsUpdate()){
+            logger.debug("Result not cached, attempting to query database.");
+            lastSelectAll = currentDao.selectAll();
+            setLastUpdate();
+            return lastSelectAll;
+        }
+
+        logger.debug("Cache exists. Returning cached result.");
+        return logger.traceExit(lastSelectAll);
+    }
+
+    public boolean needsUpdate(){
+        boolean timedOut = now().getNano() / 1000_000_000 - lastUpdate > 30;
+
+        return timedOut || invalidateCache;
+    }
+
+    public void setLastUpdate(){
+        lastUpdate = now().getNano() / 1000_000_000;
+    }
+}

--- a/src/main/java/dao/mybatis/proxy/MyBatisPrescriptionHasMedicineDAOProxy.java
+++ b/src/main/java/dao/mybatis/proxy/MyBatisPrescriptionHasMedicineDAOProxy.java
@@ -1,0 +1,147 @@
+package dao.mybatis.proxy;
+
+import dao.interfaces.PrescriptionHasMedicineDAO;
+import dao.mybatis.MyBatisPrescriptionHasMedicineDAO;
+import models.PrescriptionHasMedicine;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+
+import java.util.AbstractMap.SimpleEntry;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Optional;
+
+import static java.time.Instant.now;
+
+public class MyBatisPrescriptionHasMedicineDAOProxy extends CacheProxy implements PrescriptionHasMedicineDAO {
+    private MyBatisPrescriptionHasMedicineDAO currentDao = new MyBatisPrescriptionHasMedicineDAO();
+    private Logger logger = LogManager.getLogger(MyBatisPrescriptionHasMedicineDAOProxy.class);
+
+    private HashMap<SimpleEntry<Integer, Integer>, Optional<PrescriptionHasMedicine>> lastSelectedPrescriptionHasMedicine = new HashMap<>();
+    private List<PrescriptionHasMedicine> lastSelectAll = null;
+    private HashMap<Integer, List<PrescriptionHasMedicine>> lastSelectAllByPrescription = new HashMap<>();
+    private HashMap<Integer, List<PrescriptionHasMedicine>> lastSelectAllByMedicine = new HashMap<>();
+
+    /**
+     * @param obj
+     */
+    @Override
+    public int insert(PrescriptionHasMedicine obj) {
+        logger.traceEntry();
+        logger.debug("Attempting to insert object.");
+        return logger.traceExit(currentDao.insert(obj));
+    }
+
+    /**
+     * @param obj
+     */
+    @Override
+    public int update(PrescriptionHasMedicine obj) {
+        logger.traceEntry();
+        logger.debug("Attempting to update object.");
+
+        int modifiedRows = currentDao.update(obj);
+        invalidateCache = modifiedRows > 0;
+
+        return logger.traceExit(modifiedRows);
+    }
+
+    @Override
+    public int delete(int prescriptionId, int medicineId) {
+        logger.traceEntry();
+        logger.debug("Attempting to delete object.");
+
+        int deletedId = currentDao.delete(prescriptionId, medicineId);
+        invalidateCache = deletedId > 0;
+
+        return logger.traceExit(deletedId);
+    }
+
+    @Override
+    public Optional<PrescriptionHasMedicine> select(int prescriptionId, int medicineId) {
+        logger.traceEntry();
+        logger.debug("Checking PrescriptionHasMedicine selectById cache.");
+
+        SimpleEntry<Integer, Integer> ids = new SimpleEntry<>(prescriptionId, medicineId);
+
+        if (lastSelectedPrescriptionHasMedicine.get(ids) == null || needsUpdate()){
+            logger.debug("Result not cached, attempting to query database.");
+            lastSelectedPrescriptionHasMedicine.put(ids, currentDao.select(prescriptionId, medicineId));
+            setLastUpdate();
+            return lastSelectedPrescriptionHasMedicine.get(ids);
+        }
+
+        logger.debug("Cache exists. Returning cached result.");
+        return logger.traceExit(lastSelectedPrescriptionHasMedicine.get(ids));
+    }
+
+    /**
+     * @return
+     */
+    @Override
+    public List<PrescriptionHasMedicine> selectAll() {
+        logger.traceEntry();
+        logger.debug("Checking PrescriptionHasMedicine selectAll cache.");
+        if (lastSelectAll == null || needsUpdate()){
+            logger.debug("Result not cached, attempting to query database.");
+            lastSelectAll = currentDao.selectAll();
+            setLastUpdate();
+            return lastSelectAll;
+        }
+
+        logger.debug("Cache exists. Returning cached result.");
+        return logger.traceExit(lastSelectAll);
+    }
+
+    /**
+     * @param prescriptionId
+     * @return
+     */
+    @Override
+    public List<PrescriptionHasMedicine> selectByPrescription(int prescriptionId) {
+        logger.traceEntry();
+        logger.debug("Checking PrescriptionHasMedicine selectByPrescription cache.");
+
+        // If there is no result cached for given prescription
+        if (lastSelectAllByPrescription.get(prescriptionId) == null || needsUpdate()){
+            logger.debug("Result not cached, attempting to query database.");
+            //Cache the results for the given prescriptionId
+            lastSelectAllByPrescription.put(prescriptionId, currentDao.selectByPrescription(prescriptionId));
+            //Reset last update time
+            setLastUpdate();
+            //Return cached results
+            return lastSelectAllByPrescription.get(prescriptionId);
+        }
+        // There exist a cached result and update time hasn't been reached
+
+        logger.debug("Cache exists. Returning cached result.");
+        //Returns cached result
+        return logger.traceExit(lastSelectAllByPrescription.get(prescriptionId));
+    }
+
+    /**
+     * @param medicineId
+     * @return
+     */
+    @Override
+    public List<PrescriptionHasMedicine> selectByMedicine(int medicineId) {
+        logger.traceEntry();
+        logger.debug("Checking PrescriptionHasMedicine selectByPrescription cache.");
+
+        // If there is no result cached for given prescription
+        if (lastSelectAllByMedicine.get(medicineId) == null || needsUpdate()){
+            logger.debug("Result not cached, attempting to query database.");
+            //Cache the results for the given prescriptionId
+            lastSelectAllByMedicine.put(medicineId, currentDao.selectByMedicine(medicineId));
+            //Reset last update time
+            setLastUpdate();
+            //Return cached results
+            return lastSelectAllByMedicine.get(medicineId);
+        }
+        // There exist a cached result and update time hasn't been reached
+
+        logger.debug("Cache exists. Returning cached result.");
+        //Returns cached result
+        return logger.traceExit(lastSelectAllByMedicine.get(medicineId));
+    }
+}

--- a/src/main/java/dao/mybatis/proxy/MyBatisServiceDAOProxy.java
+++ b/src/main/java/dao/mybatis/proxy/MyBatisServiceDAOProxy.java
@@ -1,0 +1,113 @@
+package dao.mybatis.proxy;
+
+import dao.interfaces.ServiceDAO;
+import dao.mybatis.MyBatisServiceDAO;
+import models.Service;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Optional;
+
+import static java.time.Instant.now;
+
+public class MyBatisServiceDAOProxy extends CacheProxy implements ServiceDAO {
+    private MyBatisServiceDAO currentDao = new MyBatisServiceDAO();
+    private Logger logger = LogManager.getLogger(MyBatisServiceDAOProxy.class);
+
+    private HashMap<Integer, Optional<Service>> lastSelected = new HashMap<>();
+    private List<Service> lastSelectAll = null;
+
+    /**
+     * @param obj
+     */
+    @Override
+    public int insert(Service obj) {
+        logger.traceEntry();
+        logger.debug("Attempting to insert service.");
+
+        int modifiedRows = currentDao.insert(obj);
+        invalidateCache = modifiedRows > 0;
+
+        return logger.traceExit(modifiedRows);
+    }
+
+    /**
+     * @param id
+     * @param obj
+     */
+    @Override
+    public int update(int id, Service obj) {
+        logger.traceEntry();
+        logger.debug("Attempting to update service.");
+
+        int modifiedRows = currentDao.update(id, obj);
+        invalidateCache = modifiedRows > 0;
+
+        return logger.traceExit(modifiedRows);
+    }
+
+    /**
+     * @param id
+     */
+    @Override
+    public int delete(int id) {
+        logger.traceEntry();
+        logger.debug("Attempting to delete service.");
+
+        int modifiedRows = currentDao.delete(id);
+        invalidateCache = modifiedRows > 0;
+
+        return logger.traceExit(modifiedRows);
+    }
+
+    /**
+     * @param id
+     * @return
+     */
+    @Override
+    public Optional<Service> select(int id) {
+        logger.traceEntry();
+        logger.debug("Checking Service selectById cache.");
+
+        if (lastSelected.get(id) == null || needsUpdate()){
+            logger.debug("Result not cached, attempting to query database.");
+            lastSelected.put(id, currentDao.select(id));
+            setLastUpdate();
+            return lastSelected.get(id);
+        }
+
+        logger.debug("Cache exists. Returning cached result.");
+        return logger.traceExit(lastSelected.get(id));
+    }
+
+    /**
+     * @return
+     */
+    @Override
+    public List<Service> selectAll() {
+        logger.traceEntry();
+        logger.debug("Checking Service selectById cache.");
+
+        if (lastSelectAll == null || needsUpdate()){
+            logger.debug("Result not cached, attempting to query database.");
+            lastSelectAll = currentDao.selectAll();
+            setLastUpdate();
+            return lastSelectAll;
+        }
+
+        logger.debug("Cache exists. Returning cached result.");
+        return logger.traceExit(lastSelectAll);
+    }
+
+    public boolean needsUpdate(){
+        boolean timedOut = now().getNano() / 1000_000_000 - lastUpdate > 30;
+
+        return timedOut || invalidateCache;
+    }
+
+    public void setLastUpdate(){
+        lastUpdate = now().getNano() / 1000_000_000;
+    }
+}

--- a/src/main/java/dao/mybatis/proxy/MyBatisTreatmentRecordDAOProxy.java
+++ b/src/main/java/dao/mybatis/proxy/MyBatisTreatmentRecordDAOProxy.java
@@ -1,0 +1,115 @@
+package dao.mybatis.proxy;
+
+import dao.interfaces.TreatmentRecordDAO;
+import dao.mybatis.MyBatisTreatmentRecordDAO;
+import models.TreatmentRecord;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Optional;
+
+import static java.time.Instant.now;
+
+public class MyBatisTreatmentRecordDAOProxy extends CacheProxy implements TreatmentRecordDAO {
+    private MyBatisTreatmentRecordDAO currentDao = new MyBatisTreatmentRecordDAO();
+    private Logger logger = LogManager.getLogger(MyBatisTreatmentRecordDAOProxy.class);
+
+    private HashMap<Integer, Optional<TreatmentRecord>> lastSelected = new HashMap<>();
+    private List<TreatmentRecord> lastSelectAll = null;
+    private long lastUpdate = now().getNano() / 1000_000_000;
+    private boolean invalidateCache = false;
+
+    /**
+     * @param obj
+     */
+    @Override
+    public int insert(TreatmentRecord obj) {
+        logger.traceEntry();
+        logger.debug("Attempting to insert treatmentRecord.");
+
+        int modifiedRows = currentDao.insert(obj);
+        invalidateCache = modifiedRows > 0;
+
+        return logger.traceExit(modifiedRows);
+    }
+
+    /**
+     * @param id
+     * @param obj
+     */
+    @Override
+    public int update(int id, TreatmentRecord obj) {
+        logger.traceEntry();
+        logger.debug("Attempting to update treatmentRecord.");
+
+        int modifiedRows = currentDao.update(id, obj);
+        invalidateCache = modifiedRows > 0;
+
+        return logger.traceExit(modifiedRows);
+    }
+
+    /**
+     * @param id
+     */
+    @Override
+    public int delete(int id) {
+        logger.traceEntry();
+        logger.debug("Attempting to delete treatmentRecord.");
+
+        int modifiedRows = currentDao.delete(id);
+        invalidateCache = modifiedRows > 0;
+
+        return logger.traceExit(modifiedRows);
+    }
+
+    /**
+     * @param id
+     * @return
+     */
+    @Override
+    public Optional<TreatmentRecord> select(int id) {
+        logger.traceEntry();
+        logger.debug("Checking TreatmentRecord selectById cache.");
+
+        if (lastSelected.get(id) == null || needsUpdate()){
+            logger.debug("Result not cached, attempting to query database.");
+            lastSelected.put(id, currentDao.select(id));
+            setLastUpdate();
+            return lastSelected.get(id);
+        }
+
+        logger.debug("Cache exists. Returning cached result.");
+        return logger.traceExit(lastSelected.get(id));
+    }
+
+    /**
+     * @return
+     */
+    @Override
+    public List<TreatmentRecord> selectAll() {
+        logger.traceEntry();
+        logger.debug("Checking TreatmentRecord selectById cache.");
+
+        if (lastSelectAll == null || needsUpdate()){
+            logger.debug("Result not cached, attempting to query database.");
+            lastSelectAll = currentDao.selectAll();
+            setLastUpdate();
+            return lastSelectAll;
+        }
+
+        logger.debug("Cache exists. Returning cached result.");
+        return logger.traceExit(lastSelectAll);
+    }
+
+    public boolean needsUpdate(){
+        boolean timedOut = now().getNano() / 1000_000_000 - lastUpdate > 30;
+
+        return timedOut || invalidateCache;
+    }
+
+    public void setLastUpdate(){
+        lastUpdate = now().getNano() / 1000_000_000;
+    }
+}

--- a/src/main/java/menu/InvoiceHasServiceMenuHandler.java
+++ b/src/main/java/menu/InvoiceHasServiceMenuHandler.java
@@ -45,6 +45,7 @@ public class InvoiceHasServiceMenuHandler extends MenuHandler {
                     invoiceId = invoiceHasServiceController.requestId();
                     serviceId = invoiceHasServiceController.requestId();
                     logger.info("Deleting invoiceHasService with invoiceId: {} and serviceId: {}", invoiceId, serviceId);
+                    invoiceHasServiceController.delete(invoiceId, serviceId);
                     break;
                 case 5:
                     InvoiceHasService newRecord = invoiceHasServiceController.getData();

--- a/src/main/java/menu/MenuHandler.java
+++ b/src/main/java/menu/MenuHandler.java
@@ -77,6 +77,8 @@ public abstract class MenuHandler {
             case 10 -> new ServiceMenuHandler(daoFactory).processMenuOption();
             case 11 -> new ExportXMLMenuHandler(daoFactory).processMenuOption();
             case 12 -> new ExportJSONMenuHandler(daoFactory).processMenuOption();
+            case 13 -> new InvoiceHasServiceMenuHandler(daoFactory).processMenuOption();
+            case 14 -> new PrescriptionHasMedicineMenuHandler(daoFactory).processMenuOption();
             default -> exit(0);
         }
     }

--- a/src/main/java/menu/PrescriptionHasMedicineMenuHandler.java
+++ b/src/main/java/menu/PrescriptionHasMedicineMenuHandler.java
@@ -45,6 +45,7 @@ public class PrescriptionHasMedicineMenuHandler extends MenuHandler {
                     prescriptionId = prescriptionHasMedicineController.requestId();
                     medicineId = prescriptionHasMedicineController.requestId();
                     logger.info("Deleting prescriptionHasMedicine with prescriptionId: {} and medicineId: {}", prescriptionId, medicineId);
+                    prescriptionHasMedicineController.delete(prescriptionId, medicineId);
                     break;
                 case 5:
                     PrescriptionHasMedicine newRecord = prescriptionHasMedicineController.getData();

--- a/src/main/java/views/EntitySelection.java
+++ b/src/main/java/views/EntitySelection.java
@@ -30,7 +30,9 @@ public final class EntitySelection extends FeedbackView {
         System.out.println("10 - Service");
         System.out.println("11 - Dump database to XML");
         System.out.println("12 - Dump database to JSON");
-        System.out.println("13 - Exit");
+        System.out.println("13 - InvoiceHasService");
+        System.out.println("14 - PrescriptionHasMedicine");
+        System.out.println("15 - Exit");
     }
 
     public HashMap<String, String> getInputs(){
@@ -41,7 +43,7 @@ public final class EntitySelection extends FeedbackView {
         processInputs(stringInputs);
 
         int val = Integer.parseInt(inputs.get("menuOption"));
-        if (val < 1 || val > 13){
+        if (val < 1 || val > 15){
             System.out.println("Option is not valid, please try again.");
             getInputs();
         }


### PR DESCRIPTION
Added the options InvoiceHasServide and PrescriptionHasMedicine to the entity selection menu.
MyBatisDAOFactory now returns a MyBatisInvoiceHasServiceDAOProxy object instead.
MyBatisInvoiceHasServiceDAOProxy is intended to soft-cache selection statements until either an update or delete statement is executed.